### PR TITLE
Rebuild finance dashboard inside existing frontend workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-"# Meu Projeto" 
+# Painel Financeiro
+
+Projeto frontend criado com Vite + React + TypeScript localizado em `frontend/`. O dashboard oferece autenticação mock, formulários de entradas/saídas, gestão de contas a pagar, métricas consolidadas e gráfico de pizza estilizado com Tailwind CSS.
+
+## Executando localmente
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+O servidor ficará disponível em `http://localhost:5173`.
+
+## Principais funcionalidades
+
+- Login com validação e persistência básica em `localStorage`.
+- Contextos (`AuthContext` e `FinanceContext`) para gerenciar sessão, transações e contas a pagar.
+- Formulários responsivos para registrar entradas, saídas e contas a pagar com feedback visual.
+- Métricas consolidadas, cards de resumo e meta de reserva financeira com barra de progresso.
+- Gráfico de pizza via `react-chartjs-2` exibindo distribuição de categorias.
+- Estilização sofisticada com Tailwind CSS e layout inspirado em painéis SaaS.
+- Placeholder de integração futura disponível em `src/services/transactions.ts`.
+
+## Estrutura
+
+```
+frontend/
+├── index.html
+├── package.json
+├── src
+│   ├── App.tsx
+│   ├── components/
+│   ├── context/
+│   ├── pages/
+│   ├── services/
+│   └── styles/
+└── vite.config.ts
+```
+
+Ajuste conforme necessário para integração com APIs reais ou implantação em plataformas como Vercel.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+.vscode
+.env.local

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Painel Financeiro</title>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "finance-dashboard",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.19",
+    "@heroicons/react": "^2.1.5",
+    "chart.js": "^4.4.1",
+    "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.49.3",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.55",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react-swc": "^3.6.0",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.4"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,30 @@
+import { Navigate, Route, Routes } from "react-router-dom";
+
+import Layout from "./components/Layout";
+import { ProtectedRoute } from "./components/ProtectedRoute";
+import { useAuth } from "./context/AuthContext";
+import Dashboard from "./pages/Dashboard";
+import Login from "./pages/Login";
+
+const App = () => {
+  const { isAuthenticated } = useAuth();
+
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute>
+            <Layout>
+              <Dashboard />
+            </Layout>
+          </ProtectedRoute>
+        }
+      />
+      <Route path="*" element={<Navigate to={isAuthenticated ? "/" : "/login"} replace />} />
+    </Routes>
+  );
+};
+
+export default App;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,215 @@
+import { Fragment, PropsWithChildren, useState } from "react";
+import { Dialog, Menu, Transition } from "@headlessui/react";
+import { Bars3Icon, BellIcon, Cog6ToothIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { useNavigate } from "react-router-dom";
+
+import { useAuth } from "../context/AuthContext";
+
+const navigation = [
+  { name: "Dashboard", href: "/" },
+  { name: "Contas", href: "#payables" },
+  { name: "Relatórios", href: "#analytics" }
+];
+
+const classNames = (...classes: (string | false | null | undefined)[]) => classes.filter(Boolean).join(" ");
+
+const Layout = ({ children }: PropsWithChildren) => {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { user, signOut } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    signOut();
+    navigate("/login", { replace: true });
+  };
+
+  const today = new Date().toLocaleDateString("pt-BR", {
+    weekday: "long",
+    month: "long",
+    day: "numeric"
+  });
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <Transition.Root show={sidebarOpen} as={Fragment}>
+        <Dialog as="div" className="relative z-50 lg:hidden" onClose={setSidebarOpen}>
+          <Transition.Child
+            as={Fragment}
+            enter="transition-opacity ease-linear duration-200"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="transition-opacity ease-linear duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-slate-900/80" />
+          </Transition.Child>
+
+          <div className="fixed inset-0 flex">
+            <Transition.Child
+              as={Fragment}
+              enter="transition ease-in-out duration-200 transform"
+              enterFrom="-translate-x-full"
+              enterTo="translate-x-0"
+              leave="transition ease-in-out duration-200 transform"
+              leaveFrom="translate-x-0"
+              leaveTo="-translate-x-full"
+            >
+              <Dialog.Panel className="relative mr-16 flex w-full max-w-xs flex-1">
+                <Transition.Child
+                  as={Fragment}
+                  enter="ease-in-out duration-200"
+                  enterFrom="opacity-0"
+                  enterTo="opacity-100"
+                  leave="ease-in-out duration-200"
+                  leaveFrom="opacity-100"
+                  leaveTo="opacity-0"
+                >
+                  <div className="absolute left-full top-0 flex w-16 justify-center pt-5">
+                    <button
+                      type="button"
+                      className="-m-2.5 p-2.5 text-slate-100"
+                      onClick={() => setSidebarOpen(false)}
+                    >
+                      <span className="sr-only">Fechar menu</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
+                  </div>
+                </Transition.Child>
+                <div className="flex grow flex-col gap-y-5 overflow-y-auto bg-slate-900 px-6 pb-4 ring-1 ring-white/10">
+                  <div className="flex h-16 shrink-0 items-center">
+                    <span className="text-lg font-semibold tracking-tight text-brand-300">
+                      Finanças Inteligentes
+                    </span>
+                  </div>
+                  <nav className="flex flex-1 flex-col">
+                    <ul role="list" className="flex flex-1 flex-col gap-y-7">
+                      <li>
+                        <ul role="list" className="-mx-2 space-y-1">
+                          {navigation.map((item) => (
+                            <li key={item.name}>
+                              <a
+                                href={item.href}
+                                className="group flex gap-x-3 rounded-md px-3 py-2 text-sm font-semibold leading-6 text-slate-200 hover:bg-slate-800/80 hover:text-white"
+                                onClick={() => setSidebarOpen(false)}
+                              >
+                                {item.name}
+                              </a>
+                            </li>
+                          ))}
+                        </ul>
+                      </li>
+                    </ul>
+                  </nav>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </Dialog>
+      </Transition.Root>
+
+      <div className="hidden lg:fixed lg:inset-y-0 lg:z-40 lg:flex lg:w-72 lg:flex-col">
+        <div className="flex grow flex-col gap-y-8 overflow-y-auto bg-slate-900/60 px-6 pb-8 pt-10 ring-1 ring-white/5">
+          <div className="flex h-16 shrink-0 items-center">
+            <span className="text-lg font-semibold tracking-tight text-brand-200">
+              Finanças Inteligentes
+            </span>
+          </div>
+          <nav className="flex flex-1 flex-col">
+            <ul role="list" className="flex flex-1 flex-col gap-y-7">
+              <li>
+                <ul role="list" className="-mx-2 space-y-1">
+                  {navigation.map((item) => (
+                    <li key={item.name}>
+                      <a
+                        href={item.href}
+                        className="group flex gap-x-3 rounded-md px-3 py-2 text-sm font-semibold leading-6 text-slate-300 hover:bg-slate-800/80 hover:text-white"
+                      >
+                        {item.name}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+
+      <div className="lg:pl-72">
+        <div className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-white/10 bg-slate-950/70 px-4 shadow-inner backdrop-blur-lg sm:px-6 lg:px-8">
+          <button
+            type="button"
+            className="-m-2.5 p-2.5 text-slate-100 lg:hidden"
+            onClick={() => setSidebarOpen(true)}
+          >
+            <span className="sr-only">Abrir menu</span>
+            <Bars3Icon className="h-6 w-6" aria-hidden="true" />
+          </button>
+
+          <div className="flex flex-1 items-center gap-x-4 self-stretch lg:gap-x-6">
+            <div className="text-sm text-slate-400">{today}</div>
+            <div className="relative ml-auto flex items-center gap-x-4">
+              <button
+                type="button"
+                className="rounded-full bg-brand-500/10 p-1 text-brand-300 hover:text-brand-200"
+              >
+                <span className="sr-only">Ver notificações</span>
+                <BellIcon className="h-6 w-6" aria-hidden="true" />
+              </button>
+              <Menu as="div" className="relative">
+                <Menu.Button className="flex items-center gap-x-3 rounded-full bg-slate-900/60 px-3 py-1 text-sm font-semibold leading-6 text-slate-200 shadow-glass ring-1 ring-white/10">
+                  <span>{user?.email ?? "Usuário"}</span>
+                </Menu.Button>
+                <Transition
+                  as={Fragment}
+                  enter="transition ease-out duration-100"
+                  enterFrom="transform opacity-0 scale-95"
+                  enterTo="transform opacity-100 scale-100"
+                  leave="transition ease-in duration-75"
+                  leaveFrom="transform opacity-100 scale-100"
+                  leaveTo="transform opacity-0 scale-95"
+                >
+                  <Menu.Items className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-xl bg-slate-900/95 p-1 shadow-lg ring-1 ring-black/5 focus:outline-none">
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          type="button"
+                          className={classNames(
+                            active ? "bg-slate-800/70" : "",
+                            "flex w-full items-center gap-x-2 rounded-lg px-3 py-2 text-sm text-slate-200"
+                          )}
+                        >
+                          <Cog6ToothIcon className="h-5 w-5" />
+                          Configurações
+                        </button>
+                      )}
+                    </Menu.Item>
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          type="button"
+                          onClick={handleLogout}
+                          className={classNames(
+                            active ? "bg-red-500/10 text-red-200" : "text-slate-200",
+                            "flex w-full items-center gap-x-2 rounded-lg px-3 py-2 text-sm"
+                          )}
+                        >
+                          Sair
+                        </button>
+                      )}
+                    </Menu.Item>
+                  </Menu.Items>
+                </Transition>
+              </Menu>
+            </div>
+          </div>
+        </div>
+
+        <main className="px-4 py-10 sm:px-6 lg:px-8">{children}</main>
+      </div>
+    </div>
+  );
+};
+
+export default Layout;

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,15 @@
+import { Navigate, useLocation } from "react-router-dom";
+import type { PropsWithChildren } from "react";
+
+import { useAuth } from "../context/AuthContext";
+
+export const ProtectedRoute = ({ children }: PropsWithChildren) => {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,96 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from "react";
+
+type AuthUser = {
+  email: string;
+};
+
+type SignInPayload = {
+  email: string;
+  password: string;
+};
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  signIn: (payload: SignInPayload) => Promise<void>;
+  signOut: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const STORAGE_KEY = "finance-dashboard::auth";
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isReady, setReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const persisted = window.localStorage.getItem(STORAGE_KEY);
+      if (persisted) {
+        const parsed = JSON.parse(persisted) as AuthUser;
+        setUser(parsed);
+      }
+    } catch (error) {
+      console.error("Falha ao restaurar autenticação", error);
+    } finally {
+      setReady(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !isReady) return;
+    if (user) {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [user, isReady]);
+
+  const signIn = useCallback(async ({ email, password }: SignInPayload) => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    if (!email || !password) {
+      throw new Error("Informe e-mail e senha válidos");
+    }
+
+    setUser({ email });
+  }, []);
+
+  const signOut = useCallback(() => {
+    setUser(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      user,
+      isAuthenticated: Boolean(user),
+      signIn,
+      signOut
+    }),
+    [user, signIn, signOut]
+  );
+
+  if (!isReady) {
+    return <div className="flex h-screen items-center justify-center text-slate-300">Carregando...</div>;
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth deve ser utilizado dentro de AuthProvider");
+  }
+  return context;
+};

--- a/frontend/src/context/FinanceContext.tsx
+++ b/frontend/src/context/FinanceContext.tsx
@@ -1,0 +1,256 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef
+} from "react";
+
+import { fetchTransactionsMock } from "../services/transactions";
+
+type TransactionBase = {
+  description: string;
+  amount: number;
+  category: string;
+  counterparty: string;
+  date: string;
+};
+
+export type TransactionType = "income" | "expense";
+
+export type Transaction = TransactionBase & {
+  id: string;
+  type: TransactionType;
+};
+
+export type PayableStatus = "pending" | "paid";
+
+export type Payable = {
+  id: string;
+  description: string;
+  amount: number;
+  counterparty: string;
+  dueDate: string;
+  status: PayableStatus;
+};
+
+type FinanceState = {
+  transactions: Transaction[];
+  payables: Payable[];
+  savingsTarget: number;
+};
+
+type FinanceAction =
+  | { type: "ADD_TRANSACTION"; payload: Transaction }
+  | { type: "ADD_PAYABLE"; payload: Payable }
+  | { type: "TOGGLE_PAYABLE"; payload: { id: string } }
+  | { type: "UPDATE_SAVINGS_TARGET"; payload: { target: number } }
+  | { type: "HYDRATE"; payload: FinanceState };
+
+type FinanceContextValue = {
+  transactions: Transaction[];
+  payables: Payable[];
+  savingsTarget: number;
+  reserveBalance: number;
+  metrics: {
+    totalIncome: number;
+    totalExpenses: number;
+    monthlyAverage: number;
+    categories: { label: string; value: number; type: TransactionType }[];
+  };
+  addTransaction: (payload: Omit<Transaction, "id">) => void;
+  addPayable: (payload: Omit<Payable, "id" | "status">) => void;
+  togglePayableStatus: (id: string) => void;
+  updateSavingsTarget: (target: number) => void;
+};
+
+const FinanceContext = createContext<FinanceContextValue | undefined>(undefined);
+
+const STORAGE_KEY = "finance-dashboard::data";
+
+const initialState: FinanceState = {
+  transactions: [],
+  payables: [],
+  savingsTarget: 5000
+};
+
+const financeReducer = (state: FinanceState, action: FinanceAction): FinanceState => {
+  switch (action.type) {
+    case "HYDRATE":
+      return action.payload;
+    case "ADD_TRANSACTION":
+      return {
+        ...state,
+        transactions: [action.payload, ...state.transactions]
+      };
+    case "ADD_PAYABLE":
+      return {
+        ...state,
+        payables: [action.payload, ...state.payables]
+      };
+    case "TOGGLE_PAYABLE":
+      return {
+        ...state,
+        payables: state.payables.map((payable) =>
+          payable.id === action.payload.id
+            ? { ...payable, status: payable.status === "pending" ? "paid" : "pending" }
+            : payable
+        )
+      };
+    case "UPDATE_SAVINGS_TARGET":
+      return {
+        ...state,
+        savingsTarget: action.payload.target
+      };
+    default:
+      return state;
+  }
+};
+
+const generateId = () => crypto.randomUUID?.() ?? Math.random().toString(36).slice(2, 11);
+
+const deserializeState = (value: string | null): FinanceState | null => {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as FinanceState;
+    return {
+      transactions: parsed.transactions ?? [],
+      payables: parsed.payables ?? [],
+      savingsTarget: typeof parsed.savingsTarget === "number" ? parsed.savingsTarget : 5000
+    };
+  } catch (error) {
+    console.warn("Não foi possível restaurar dados financeiros", error);
+    return null;
+  }
+};
+
+const serializeState = (state: FinanceState) => JSON.stringify(state);
+
+export const FinanceProvider = ({ children }: { children: ReactNode }) => {
+  const [state, dispatch] = useReducer(financeReducer, initialState);
+  const isBrowser = typeof window !== "undefined";
+  const hasHydrated = useRef(false);
+
+  useEffect(() => {
+    if (!isBrowser) return;
+    if (hasHydrated.current) return;
+
+    const restored = deserializeState(window.localStorage.getItem(STORAGE_KEY));
+    if (restored) {
+      dispatch({ type: "HYDRATE", payload: restored });
+      hasHydrated.current = true;
+      return;
+    }
+
+    const seedData = async () => {
+      try {
+        const data = await fetchTransactionsMock();
+        hasHydrated.current = true;
+        data.forEach((transaction) =>
+          dispatch({
+            type: "ADD_TRANSACTION",
+            payload: {
+              ...transaction,
+              id: transaction.id || generateId()
+            }
+          })
+        );
+      } catch (error) {
+        console.error("Falha ao carregar dados mockados", error);
+        hasHydrated.current = true;
+      }
+    };
+
+    seedData();
+  }, [isBrowser]);
+
+  useEffect(() => {
+    if (!isBrowser) return;
+    window.localStorage.setItem(STORAGE_KEY, serializeState(state));
+  }, [state, isBrowser]);
+
+  const addTransaction = useCallback((payload: Omit<Transaction, "id">) => {
+    const transaction: Transaction = { ...payload, id: generateId() };
+    dispatch({ type: "ADD_TRANSACTION", payload: transaction });
+  }, []);
+
+  const addPayable = useCallback((payload: Omit<Payable, "id" | "status">) => {
+    const payable: Payable = { ...payload, id: generateId(), status: "pending" };
+    dispatch({ type: "ADD_PAYABLE", payload: payable });
+  }, []);
+
+  const togglePayableStatus = useCallback((id: string) => {
+    dispatch({ type: "TOGGLE_PAYABLE", payload: { id } });
+  }, []);
+
+  const updateSavingsTarget = useCallback((target: number) => {
+    dispatch({ type: "UPDATE_SAVINGS_TARGET", payload: { target } });
+  }, []);
+
+  const metrics = useMemo(() => {
+    const totalIncome = state.transactions
+      .filter((transaction) => transaction.type === "income")
+      .reduce((sum, transaction) => sum + transaction.amount, 0);
+
+    const totalExpenses = state.transactions
+      .filter((transaction) => transaction.type === "expense")
+      .reduce((sum, transaction) => sum + transaction.amount, 0);
+
+    const categories = state.transactions.reduce<
+      { label: string; value: number; type: TransactionType }[]
+    >((acc, transaction) => {
+      const key = `${transaction.type}-${transaction.category}`;
+      const existing = acc.find((category) => `${category.type}-${category.label}` === key);
+      if (existing) {
+        existing.value += transaction.amount;
+      } else {
+        acc.push({ label: transaction.category, value: transaction.amount, type: transaction.type });
+      }
+      return acc;
+    }, []);
+
+    const monthlyAverage = state.transactions.length
+      ? (totalExpenses / Math.max(new Set(state.transactions.map((t) => t.date.slice(0, 7))).size, 1))
+      : 0;
+
+    return {
+      totalIncome,
+      totalExpenses,
+      monthlyAverage,
+      categories
+    };
+  }, [state.transactions]);
+
+  const reserveBalance = useMemo(() => {
+    const net = metrics.totalIncome - metrics.totalExpenses;
+    return Math.max(net * 0.25, 0);
+  }, [metrics.totalIncome, metrics.totalExpenses]);
+
+  const value = useMemo<FinanceContextValue>(
+    () => ({
+      transactions: state.transactions,
+      payables: state.payables,
+      savingsTarget: state.savingsTarget,
+      reserveBalance,
+      metrics,
+      addTransaction,
+      addPayable,
+      togglePayableStatus,
+      updateSavingsTarget
+    }),
+    [state.transactions, state.payables, state.savingsTarget, reserveBalance, metrics, addTransaction, addPayable, togglePayableStatus, updateSavingsTarget]
+  );
+
+  return <FinanceContext.Provider value={value}>{children}</FinanceContext.Provider>;
+};
+
+export const useFinance = () => {
+  const context = useContext(FinanceContext);
+  if (!context) {
+    throw new Error("useFinance deve ser utilizado dentro de FinanceProvider");
+  }
+  return context;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+
+import App from "./App";
+import { AuthProvider } from "./context/AuthContext";
+import { FinanceProvider } from "./context/FinanceContext";
+import "./styles/index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <FinanceProvider>
+          <App />
+        </FinanceProvider>
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,611 @@
+import { ChangeEvent, Dispatch, FormEvent, SetStateAction, useMemo, useState } from "react";
+import { Pie } from "react-chartjs-2";
+import {
+  ArcElement,
+  Chart as ChartJS,
+  Legend,
+  Tooltip
+} from "chart.js";
+
+import { Payable, TransactionType, useFinance } from "../context/FinanceContext";
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+type TransactionFormState = {
+  amount: string;
+  description: string;
+  category: string;
+  counterparty: string;
+  date: string;
+};
+
+type PayableFormState = {
+  description: string;
+  amount: string;
+  dueDate: string;
+  counterparty: string;
+};
+
+const transactionInitialState: TransactionFormState = {
+  amount: "",
+  description: "",
+  category: "",
+  counterparty: "",
+  date: new Date().toISOString().slice(0, 10)
+};
+
+const payableInitialState: PayableFormState = {
+  description: "",
+  amount: "",
+  dueDate: new Date().toISOString().slice(0, 10),
+  counterparty: ""
+};
+
+const categories = [
+  "Assinaturas",
+  "Folha de pagamento",
+  "Marketing",
+  "Receita recorrente",
+  "Serviços",
+  "Investimentos",
+  "Infraestrutura"
+];
+
+const currency = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL"
+});
+
+const Dashboard = () => {
+  const {
+    transactions,
+    payables,
+    addTransaction,
+    addPayable,
+    togglePayableStatus,
+    metrics,
+    reserveBalance,
+    savingsTarget,
+    updateSavingsTarget
+  } = useFinance();
+
+  const [incomeForm, setIncomeForm] = useState<TransactionFormState>(transactionInitialState);
+  const [expenseForm, setExpenseForm] = useState<TransactionFormState>(transactionInitialState);
+  const [payableForm, setPayableForm] = useState<PayableFormState>(payableInitialState);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const handleTransactionSubmit = (
+    event: FormEvent<HTMLFormElement>,
+    type: TransactionType,
+    formState: TransactionFormState,
+    setState: (state: TransactionFormState) => void
+  ) => {
+    event.preventDefault();
+    setFormError(null);
+
+    const amount = Number(formState.amount);
+    if (Number.isNaN(amount) || amount <= 0) {
+      setFormError("Informe um valor numérico positivo para a transação.");
+      return;
+    }
+
+    if (!formState.description.trim() || !formState.category.trim() || !formState.counterparty.trim()) {
+      setFormError("Descrição, categoria e origem/destino são obrigatórias.");
+      return;
+    }
+
+    addTransaction({
+      type,
+      amount,
+      description: formState.description.trim(),
+      category: formState.category.trim(),
+      counterparty: formState.counterparty.trim(),
+      date: formState.date
+    });
+
+    setState({ ...transactionInitialState, date: formState.date });
+  };
+
+  const handlePayableSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+
+    const amount = Number(payableForm.amount);
+    if (Number.isNaN(amount) || amount <= 0) {
+      setFormError("Informe um valor numérico positivo para a conta a pagar.");
+      return;
+    }
+
+    if (!payableForm.description.trim() || !payableForm.counterparty.trim()) {
+      setFormError("Descrição e fornecedor são obrigatórios.");
+      return;
+    }
+
+    addPayable({
+      description: payableForm.description.trim(),
+      amount,
+      counterparty: payableForm.counterparty.trim(),
+      dueDate: payableForm.dueDate
+    });
+
+    setPayableForm({ ...payableInitialState, dueDate: payableForm.dueDate });
+  };
+
+  const incomeData = useMemo(
+    () => metrics.categories.filter((category) => category.type === "income"),
+    [metrics.categories]
+  );
+
+  const expenseData = useMemo(
+    () => metrics.categories.filter((category) => category.type === "expense"),
+    [metrics.categories]
+  );
+
+  const pieChartData = useMemo(() => {
+    if (!metrics.categories.length) {
+      return {
+        labels: ["Sem dados"],
+        datasets: [
+          {
+            label: "Movimentações",
+            data: [1],
+            backgroundColor: ["#1F2937"],
+            borderColor: ["#1F2937"],
+            borderWidth: 2
+          }
+        ]
+      };
+    }
+
+    const labels = [
+      ...incomeData.map((item) => `Entrada · ${item.label}`),
+      ...expenseData.map((item) => `Saída · ${item.label}`)
+    ];
+    const data = [...incomeData.map((item) => item.value), ...expenseData.map((item) => item.value)];
+    const backgroundColor = [
+      "#1F3C88",
+      "#335BBF",
+      "#F9A620",
+      "#5CB8E4",
+      "#00C49A",
+      "#F55353",
+      "#8C54FF",
+      "#F59E0B"
+    ];
+
+    return {
+      labels,
+      datasets: [
+        {
+          label: "Movimentações",
+          data,
+          backgroundColor,
+          borderColor: backgroundColor,
+          borderWidth: 2
+        }
+      ]
+    };
+  }, [incomeData, expenseData, metrics.categories]);
+
+  const nextPayables = useMemo(() => {
+    return [...payables]
+      .sort((a, b) => a.dueDate.localeCompare(b.dueDate))
+      .slice(0, 5);
+  }, [payables]);
+
+  const updateFormField = (
+    setter: Dispatch<SetStateAction<TransactionFormState>>,
+    field: keyof TransactionFormState,
+    value: string
+  ) => setter((prev) => ({ ...prev, [field]: value }));
+
+  const updatePayableFormField = (field: keyof PayableFormState, value: string) => {
+    setPayableForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const savingsProgress = savingsTarget ? Math.min((reserveBalance / savingsTarget) * 100, 100) : 0;
+
+  const totalPayables = payables.reduce((sum, payable) => sum + payable.amount, 0);
+  const overduePayables = payables.filter((payable) => payable.status === "pending" && new Date(payable.dueDate) < new Date());
+
+  return (
+    <div className="space-y-10">
+      <section className="grid gap-6 lg:grid-cols-4" id="analytics">
+        <SummaryCard
+          label="Entradas no mês"
+          value={currency.format(metrics.totalIncome)}
+          helper={`${incomeData.length} categorias`}
+        />
+        <SummaryCard
+          label="Saídas no mês"
+          value={currency.format(metrics.totalExpenses)}
+          helper={`${expenseData.length} categorias`}
+        />
+        <SummaryCard
+          label="Reserva projetada"
+          value={currency.format(reserveBalance)}
+          helper="25% do saldo líquido"
+        />
+        <SummaryCard
+          label="Contas a pagar"
+          value={currency.format(totalPayables)}
+          helper={`${overduePayables.length} em atraso`}
+          tone="warning"
+        />
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-3">
+        <div className="glass-card xl:col-span-2">
+          <header className="mb-6 flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 className="section-title">Fluxo financeiro</h2>
+              <p className="text-sm text-slate-400">Distribuição de entradas e saídas por categoria.</p>
+            </div>
+          </header>
+          <div className="flex min-h-[260px] items-center justify-center">
+            <Pie
+              data={pieChartData}
+              options={{
+                plugins: {
+                  legend: {
+                    position: "bottom",
+                    labels: { color: "#cbd5f5" }
+                  }
+                }
+              }}
+            />
+          </div>
+        </div>
+
+        <div className="glass-card space-y-6">
+          <header className="space-y-2">
+            <h2 className="section-title">Meta de reservas</h2>
+            <p className="text-sm text-slate-400">Ajuste a meta mensal conforme o planejamento estratégico.</p>
+          </header>
+          <div className="space-y-4">
+            <div>
+              <div className="flex items-center justify-between text-sm text-slate-300">
+                <span>Progresso</span>
+                <span>{Math.round(savingsProgress)}%</span>
+              </div>
+              <div className="mt-2 h-3 rounded-full bg-slate-800">
+                <div
+                  className="h-3 rounded-full bg-gradient-to-r from-brand-500 via-brand-400 to-brand-300"
+                  style={{ width: `${savingsProgress}%` }}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm text-slate-300" htmlFor="savingsTarget">
+                Definir nova meta (R$)
+              </label>
+              <input
+                id="savingsTarget"
+                type="number"
+                min={0}
+                step={100}
+                className="w-full rounded-2xl border border-white/10 px-4 py-3 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+                value={savingsTarget}
+                onChange={(event) => {
+                  const newValue = Number(event.target.value);
+                  if (!Number.isNaN(newValue)) {
+                    updateSavingsTarget(newValue);
+                  }
+                }}
+              />
+            </div>
+            <p className="text-xs text-slate-500">
+              Placeholder de integração com o serviço de planejamento financeiro. Configurações adicionais serão carregadas do
+              ERP corporativo.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-3">
+        <div className="glass-card xl:col-span-2">
+          <header className="mb-6 flex items-center justify-between">
+            <div>
+              <h2 className="section-title">Registrar entrada</h2>
+              <p className="text-sm text-slate-400">Informe novas receitas para atualizar métricas imediatamente.</p>
+            </div>
+          </header>
+          <form
+            className="grid gap-4 md:grid-cols-2"
+            onSubmit={(event) => handleTransactionSubmit(event, "income", incomeForm, setIncomeForm)}
+          >
+            <InputField
+              label="Valor"
+              type="number"
+              min="0"
+              step="0.01"
+              required
+              value={incomeForm.amount}
+              onChange={(event) => updateFormField(setIncomeForm, "amount", event.target.value)}
+            />
+            <InputField
+              label="Categoria"
+              placeholder="Ex.: Receita recorrente"
+              list="category-list"
+              value={incomeForm.category}
+              onChange={(event) => updateFormField(setIncomeForm, "category", event.target.value)}
+            />
+            <InputField
+              label="Descrição"
+              placeholder="Ex.: Plano enterprise"
+              value={incomeForm.description}
+              onChange={(event) => updateFormField(setIncomeForm, "description", event.target.value)}
+            />
+            <InputField
+              label="Origem"
+              placeholder="Ex.: Cliente XPTO"
+              value={incomeForm.counterparty}
+              onChange={(event) => updateFormField(setIncomeForm, "counterparty", event.target.value)}
+            />
+            <InputField
+              label="Data"
+              type="date"
+              value={incomeForm.date}
+              onChange={(event) => updateFormField(setIncomeForm, "date", event.target.value)}
+            />
+            <div className="md:col-span-2">
+              <button
+                type="submit"
+                className="w-full rounded-2xl bg-brand-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-brand-500/20 transition hover:bg-brand-400"
+              >
+                Salvar entrada
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <div className="glass-card">
+          <header className="mb-6">
+            <h2 className="section-title">Contas a pagar</h2>
+            <p className="text-sm text-slate-400">
+              Controle fornecedores e vencimentos críticos. Em breve conectaremos com o módulo de pagamentos.
+            </p>
+          </header>
+          <form className="space-y-4" onSubmit={handlePayableSubmit} id="payables">
+            <InputField
+              label="Descrição"
+              placeholder="Ex.: Renovação de software"
+              value={payableForm.description}
+              onChange={(event) => updatePayableFormField("description", event.target.value)}
+            />
+            <InputField
+              label="Valor"
+              type="number"
+              min="0"
+              step="0.01"
+              value={payableForm.amount}
+              onChange={(event) => updatePayableFormField("amount", event.target.value)}
+            />
+            <InputField
+              label="Fornecedor"
+              placeholder="Ex.: SaaS Cloud Inc"
+              value={payableForm.counterparty}
+              onChange={(event) => updatePayableFormField("counterparty", event.target.value)}
+            />
+            <InputField
+              label="Vencimento"
+              type="date"
+              value={payableForm.dueDate}
+              onChange={(event) => updatePayableFormField("dueDate", event.target.value)}
+            />
+            <button
+              type="submit"
+              className="w-full rounded-2xl bg-gradient-to-r from-red-500 via-orange-500 to-amber-400 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-red-500/20 transition hover:from-red-500 hover:via-orange-400 hover:to-amber-300"
+            >
+              Adicionar conta
+            </button>
+          </form>
+        </div>
+
+        <div className="glass-card xl:col-span-2">
+          <header className="mb-6 flex items-center justify-between">
+            <div>
+              <h2 className="section-title">Registrar saída</h2>
+              <p className="text-sm text-slate-400">Documente despesas para manter o controle de fluxo de caixa.</p>
+            </div>
+          </header>
+          <form
+            className="grid gap-4 md:grid-cols-2"
+            onSubmit={(event) => handleTransactionSubmit(event, "expense", expenseForm, setExpenseForm)}
+          >
+            <InputField
+              label="Valor"
+              type="number"
+              min="0"
+              step="0.01"
+              required
+              value={expenseForm.amount}
+              onChange={(event) => updateFormField(setExpenseForm, "amount", event.target.value)}
+            />
+            <InputField
+              label="Categoria"
+              placeholder="Ex.: Marketing"
+              list="category-list"
+              value={expenseForm.category}
+              onChange={(event) => updateFormField(setExpenseForm, "category", event.target.value)}
+            />
+            <InputField
+              label="Descrição"
+              placeholder="Ex.: Campanha Ads"
+              value={expenseForm.description}
+              onChange={(event) => updateFormField(setExpenseForm, "description", event.target.value)}
+            />
+            <InputField
+              label="Destino"
+              placeholder="Ex.: Agência Creativa"
+              value={expenseForm.counterparty}
+              onChange={(event) => updateFormField(setExpenseForm, "counterparty", event.target.value)}
+            />
+            <InputField
+              label="Data"
+              type="date"
+              value={expenseForm.date}
+              onChange={(event) => updateFormField(setExpenseForm, "date", event.target.value)}
+            />
+            <div className="md:col-span-2">
+              <button
+                type="submit"
+                className="w-full rounded-2xl bg-red-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-red-500/20 transition hover:bg-red-400"
+              >
+                Salvar saída
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <div className="hidden xl:block" aria-hidden="true" />
+      </section>
+
+      <section className="glass-card">
+        <header className="mb-6 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="section-title">Próximos vencimentos</h2>
+            <p className="text-sm text-slate-400">Organize prioridades e evite multas por atraso.</p>
+          </div>
+        </header>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-white/5">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-slate-400">
+                <th className="px-4 py-3">Descrição</th>
+                <th className="px-4 py-3">Fornecedor</th>
+                <th className="px-4 py-3">Vencimento</th>
+                <th className="px-4 py-3">Valor</th>
+                <th className="px-4 py-3 text-right">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5 text-sm">
+              {nextPayables.length === 0 ? (
+                <tr>
+                  <td className="px-4 py-6 text-center text-slate-500" colSpan={5}>
+                    Nenhuma conta cadastrada. Utilize o formulário ao lado para começar.
+                  </td>
+                </tr>
+              ) : (
+                nextPayables.map((payable) => (
+                  <PayableRow key={payable.id} payable={payable} onToggle={togglePayableStatus} />
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {formError && (
+        <div className="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200 shadow-inner">
+          {formError}
+        </div>
+      )}
+
+      <datalist id="category-list">
+        {categories.map((category) => (
+          <option key={category} value={category} />
+        ))}
+      </datalist>
+    </div>
+  );
+};
+
+type SummaryCardProps = {
+  label: string;
+  value: string;
+  helper?: string;
+  tone?: "default" | "warning";
+};
+
+const SummaryCard = ({ label, value, helper, tone = "default" }: SummaryCardProps) => (
+  <article
+    className={`glass-card space-y-3 border-l-4 ${
+      tone === "warning" ? "border-amber-400" : "border-brand-500"
+    }`}
+  >
+    <p className="text-sm uppercase tracking-wide text-slate-400">{label}</p>
+    <h3 className="text-2xl font-semibold text-white">{value}</h3>
+    {helper && <p className="text-xs text-slate-500">{helper}</p>}
+  </article>
+);
+
+type InputFieldProps = {
+  label: string;
+  type?: string;
+  value: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  min?: string;
+  step?: string;
+  list?: string;
+  required?: boolean;
+};
+
+const InputField = ({
+  label,
+  type = "text",
+  value,
+  onChange,
+  placeholder,
+  min,
+  step,
+  list,
+  required
+}: InputFieldProps) => (
+  <label className="space-y-2 text-sm text-slate-300">
+    <span>{label}</span>
+    <input
+      type={type}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      min={min}
+      step={step}
+      list={list}
+      required={required}
+      className="w-full rounded-2xl border border-white/10 px-4 py-3 shadow-inner focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+    />
+  </label>
+);
+
+type PayableRowProps = {
+  payable: Payable;
+  onToggle: (id: string) => void;
+};
+
+const PayableRow = ({ payable, onToggle }: PayableRowProps) => {
+  const isOverdue = payable.status === "pending" && new Date(payable.dueDate) < new Date();
+
+  return (
+    <tr className="text-slate-200">
+      <td className="px-4 py-3">
+        <div className="font-medium text-white">{payable.description}</div>
+        <div className="text-xs text-slate-500">#{payable.id.slice(-5)}</div>
+      </td>
+      <td className="px-4 py-3">{payable.counterparty}</td>
+      <td className="px-4 py-3">
+        <span className={`rounded-full px-3 py-1 text-xs ${isOverdue ? "bg-red-500/10 text-red-200" : "bg-slate-800/80"}`}>
+          {new Date(payable.dueDate).toLocaleDateString("pt-BR")}
+        </span>
+      </td>
+      <td className="px-4 py-3">{currency.format(payable.amount)}</td>
+      <td className="px-4 py-3 text-right">
+        <button
+          type="button"
+          onClick={() => onToggle(payable.id)}
+          className={`rounded-full px-4 py-1 text-xs font-semibold transition ${
+            payable.status === "paid"
+              ? "bg-green-500/10 text-green-300 hover:bg-green-500/20"
+              : "bg-amber-500/10 text-amber-300 hover:bg-amber-500/20"
+          }`}
+        >
+          {payable.status === "paid" ? "Pago" : isOverdue ? "Atrasado" : "Pendente"}
+        </button>
+      </td>
+    </tr>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { useAuth } from "../context/AuthContext";
+
+type LoginForm = {
+  email: string;
+  password: string;
+};
+
+const Login = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { signIn, isAuthenticated } = useAuth();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting }
+  } = useForm<LoginForm>({
+    defaultValues: {
+      email: "",
+      password: ""
+    }
+  });
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      const redirectTo = (location.state as { from?: { pathname: string } } | undefined)?.from?.pathname ?? "/";
+      navigate(redirectTo, { replace: true });
+    }
+  }, [isAuthenticated, navigate, location.state]);
+
+  const onSubmit = handleSubmit(async (data) => {
+    await signIn(data);
+    const redirectTo = (location.state as { from?: { pathname: string } } | undefined)?.from?.pathname ?? "/";
+    navigate(redirectTo, { replace: true });
+  });
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
+      <div className="glass-card w-full max-w-md space-y-8">
+        <div className="space-y-2 text-center">
+          <h1 className="text-3xl font-semibold tracking-tight text-white">Bem-vindo de volta</h1>
+          <p className="text-sm text-slate-400">
+            Acesse o painel financeiro usando as credenciais provisórias. Integração com SSO em breve.
+          </p>
+        </div>
+
+        <form className="space-y-6" onSubmit={onSubmit}>
+          <div className="space-y-4">
+            <label className="block text-left text-sm font-medium text-slate-200" htmlFor="email">
+              E-mail corporativo
+            </label>
+            <input
+              id="email"
+              type="email"
+              placeholder="financeiro@empresa.com"
+              className="w-full rounded-2xl border border-white/10 px-4 py-3 shadow-inner focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+              {...register("email", {
+                required: "Informe seu e-mail",
+                pattern: { value: /\S+@\S+\.\S+/, message: "E-mail inválido" }
+              })}
+            />
+            {errors.email && <p className="text-sm text-red-400">{errors.email.message}</p>}
+          </div>
+
+          <div className="space-y-4">
+            <label className="block text-left text-sm font-medium text-slate-200" htmlFor="password">
+              Senha
+            </label>
+            <input
+              id="password"
+              type="password"
+              placeholder="••••••••"
+              className="w-full rounded-2xl border border-white/10 px-4 py-3 shadow-inner focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+              {...register("password", {
+                required: "Informe sua senha",
+                minLength: { value: 6, message: "Utilize ao menos 6 caracteres" }
+              })}
+            />
+            {errors.password && <p className="text-sm text-red-400">{errors.password.message}</p>}
+          </div>
+
+          <button
+            type="submit"
+            className="w-full rounded-2xl bg-gradient-to-r from-brand-600 via-brand-500 to-brand-400 px-4 py-3 text-base font-semibold text-white shadow-lg shadow-brand-500/20 transition hover:from-brand-500 hover:via-brand-400 hover:to-brand-300 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "Validando acesso..." : "Entrar"}
+          </button>
+        </form>
+
+        <p className="text-center text-xs text-slate-500">
+          Ainda sem conta? Em breve integraremos com o diretório corporativo para provisionamento automático.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/frontend/src/services/transactions.ts
+++ b/frontend/src/services/transactions.ts
@@ -1,0 +1,37 @@
+export type TransactionResponse = {
+  id: string;
+  type: "income" | "expense";
+  description: string;
+  amount: number;
+  category: string;
+  counterparty: string;
+  date: string;
+};
+
+/**
+ * Placeholder para integração futura com API real (ex.: Vercel / Serverless). Atualmente retorna dados mockados.
+ */
+export const fetchTransactionsMock = async (): Promise<TransactionResponse[]> => {
+  await new Promise((resolve) => setTimeout(resolve, 400));
+
+  return [
+    {
+      id: "seed-1",
+      type: "income",
+      description: "Plano enterprise",
+      amount: 18990,
+      category: "Receita recorrente",
+      counterparty: "Cliente TechPro",
+      date: new Date().toISOString()
+    },
+    {
+      id: "seed-2",
+      type: "expense",
+      description: "Infraestrutura cloud",
+      amount: 8290,
+      category: "Infraestrutura",
+      counterparty: "Cloud Provider",
+      date: new Date().toISOString()
+    }
+  ];
+};

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,0 +1,23 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 antialiased;
+}
+
+input, textarea, select {
+  @apply bg-slate-900/60 text-slate-100 placeholder:text-slate-500;
+}
+
+.glass-card {
+  @apply rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-glass backdrop-blur-xl;
+}
+
+.section-title {
+  @apply text-lg font-semibold tracking-tight text-slate-100;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,31 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: "#2563eb",
+          50: "#eff6ff",
+          100: "#dbeafe",
+          200: "#bfdbfe",
+          300: "#93c5fd",
+          400: "#60a5fa",
+          500: "#3b82f6",
+          600: "#2563eb",
+          700: "#1d4ed8",
+          800: "#1e40af",
+          900: "#1e3a8a"
+        }
+      },
+      boxShadow: {
+        glass: "0 25px 50px -12px rgba(15, 23, 42, 0.6)",
+        inner: "inset 0 2px 6px rgba(148, 163, 184, 0.2)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- replace the previous Next.js scaffold with a Vite + React TypeScript app under `frontend/` to match the existing workspace structure and tooling
- rebuild authentication and finance contexts with localStorage persistence, mock seeding, and shared providers for routing via React Router
- recreate the login screen, responsive dashboard layout, transaction forms, payables table, and savings analytics using Tailwind styling and Chart.js

## Testing
- not run (npm packages unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68dc3b3ab1d0832ebb74c8497e9c3e00